### PR TITLE
Kompatibilität Contao 4 Managed Edition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
   },
   "require":{
     "php":">=5.3.2",
-    "contao/core":">=3.0,<4",
-    "contao-community-alliance/composer-plugin":"*",
+    "contao/core-bundle": ">=3.0 || ~4.1",
+    "contao-community-alliance/composer-plugin": "~2.4 || ~3.0",
     "menatwork/contao-multicolumnwizard": "~3.2"
   },
   "replace": {


### PR DESCRIPTION
In der Managed Edition unter Contao 4 ist die Erweiterung nicht über den Contao Manager installierbar.

Vlt. hilft das, am besten erstmal nur über `dev-master` zum Testen bereitstellen. ;-)
![grafik](https://user-images.githubusercontent.com/16544159/29840245-953af874-8d01-11e7-941b-84b7a9fa53ab.png)
